### PR TITLE
Fix test failures in test_pet.py, extend coverage, and add PATCH order test

### DIFF
--- a/api_helpers.py
+++ b/api_helpers.py
@@ -12,7 +12,6 @@ def post_api_data(endpoint, data):
     response = requests.post(f'{base_url}{endpoint}', json=data)
     return response
 
-# PATCH requests
 def patch_api_data(endpoint, data):
     response = requests.patch(f'{base_url}{endpoint}', json=data)
     return response

--- a/report.md
+++ b/report.md
@@ -1,0 +1,14 @@
+test_pet.py
+	•	Fixed schema validation bug in test_pet_schema (corrected pet name type).
+	•	Extended test_find_by_status_200 to cover all statuses and validate response and schema.
+	•	Added test_get_by_id_404 to check proper 404 handling for invalid pet IDs.
+	•	test_store.py
+	•	Added test_patch_order_by_id for PATCH endpoint with fixture for isolated test data.
+	•	Added assertions for status updates and response validation.
+	•	schemas.py
+	•	Corrected pet schema (name: string).
+	•	Added order schema for validation.
+	•	Bugs Found (Not all fixed)
+	•	Schema type bug (fixed).
+	•	API error message f-string bug (not fixed, out of scope).
+	•	Potential redundant logic in order update (not fixed, does not affect observable behavior).

--- a/schemas.py
+++ b/schemas.py
@@ -6,7 +6,7 @@ pet = {
             "type": "integer"
         },
         "name": {
-            "type": "integer"
+            "type": "string"
         },
         "type": {
             "type": "string",
@@ -16,5 +16,21 @@ pet = {
             "type": "string",
             "enum": ["available", "sold", "pending"]
         },
+    }
+}
+
+order = {
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "pet_id": {
+            "type": "integer"
+        },
+        "status": {
+            "type": "string",
+            "enum": ["available", "sold", "pending"]
+        }
     }
 }

--- a/server.log
+++ b/server.log
@@ -1,0 +1,6 @@
+ * Serving Flask app 'app'
+ * Debug mode: on
+[31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
+ * Running on http://127.0.0.1:5000
+[33mPress CTRL+C to quit[0m
+ * Restarting with stat

--- a/test_pet.py
+++ b/test_pet.py
@@ -26,7 +26,7 @@ TODO: Finish this test by...
 3) Validate the 'status' property in the response is equal to the expected status
 4) Validate the schema for each object in the response
 '''
-@pytest.mark.parametrize("status", [("available")])
+@pytest.mark.parametrize("status", ["available", "pending", "sold"])
 def test_find_by_status_200(status):
     test_endpoint = "/pets/findByStatus"
     params = {
@@ -34,13 +34,19 @@ def test_find_by_status_200(status):
     }
 
     response = api_helpers.get_api_data(test_endpoint, params)
-    # TODO...
+    assert response.status_code == 200
+
+    for pet in response.json():
+        assert pet['status'] == status
+        validate(instance=pet, schema=schemas.pet)
 
 '''
 TODO: Finish this test by...
 1) Testing and validating the appropriate 404 response for /pets/{pet_id}
 2) Parameterizing the test for any edge cases
 '''
-def test_get_by_id_404():
-    # TODO...
-    pass
+@pytest.mark.parametrize("pet_id", [999, -1, 0.5])
+def test_get_by_id_404(pet_id):
+    test_endpoint = f"/pets/{pet_id}"
+    response = api_helpers.get_api_data(test_endpoint)
+    assert response.status_code == 404

--- a/test_store.py
+++ b/test_store.py
@@ -12,5 +12,38 @@ TODO: Finish this test by...
 3) Validate the response codes and values
 4) Validate the response message "Order and pet status updated successfully"
 '''
-def test_patch_order_by_id():
-    pass
+@pytest.fixture
+def new_order():
+    # Create a new pet for the order
+    pet_payload = {
+        "id": 10,
+        "name": "test_pet_for_order",
+        "type": "dog",
+        "status": "available"
+    }
+    api_helpers.post_api_data("/pets/", pet_payload)
+
+    # Place an order for the new pet
+    order_payload = {
+        "pet_id": 10
+    }
+    response = api_helpers.post_api_data("/store/order", order_payload)
+
+    order_id = response.json()['id']
+    return order_id
+
+def test_patch_order_by_id(new_order):
+    order_id = new_order
+    test_endpoint = f"/store/order/{order_id}"
+    patch_payload = {
+        "status": "sold"
+    }
+
+    response = api_helpers.patch_api_data(test_endpoint, patch_payload)
+
+    assert response.status_code == 200
+    assert response.json()['message'] == "Order and pet status updated successfully"
+
+    # Optional: verify the pet's status is updated
+    pet_response = api_helpers.get_api_data("/pets/10")
+    assert pet_response.json()['status'] == 'sold'


### PR DESCRIPTION
Fixed a schema validation bug in test_pet.py by correcting the name type in the pet schema.
	•	Extended test_find_by_status_200 to cover all pet statuses (available, pending, sold), including response and schema validation for each.
	•	Added test_get_by_id_404 to verify 404 responses for invalid pet IDs.
	•	Implemented test_patch_order_by_id in test_store.py for the PATCH endpoint, including isolated fixtures and assertions on response and pet status update.
	•	Added order schema to schemas.py.
	•	Noted but did not fix: minor API error message formatting bug and potential logic redundancy in order update (see report for details).
