### PR TITLE
Finished take-home test

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -6,7 +6,7 @@ pet = {
             "type": "integer"
         },
         "name": {
-            "type": "integer"
+            "type": "string"
         },
         "type": {
             "type": "string",

--- a/test_pet.py
+++ b/test_pet.py
@@ -4,11 +4,6 @@ import schemas
 import api_helpers
 from hamcrest import assert_that, contains_string, is_
 
-'''
-TODO: Finish this test by...
-1) Troubleshooting and fixing the test failure
-The purpose of this test is to validate the response matches the expected schema defined in schemas.py
-'''
 def test_pet_schema():
     test_endpoint = "/pets/1"
 
@@ -19,28 +14,53 @@ def test_pet_schema():
     # Validate the response schema against the defined schema in schemas.py
     validate(instance=response.json(), schema=schemas.pet)
 
-'''
-TODO: Finish this test by...
-1) Extending the parameterization to include all available statuses
-2) Validate the appropriate response code
-3) Validate the 'status' property in the response is equal to the expected status
-4) Validate the schema for each object in the response
-'''
-@pytest.mark.parametrize("status", [("available")])
+
+@pytest.mark.parametrize("status", ["available", "sold", "pending"])
 def test_find_by_status_200(status):
+
     test_endpoint = "/pets/findByStatus"
+
     params = {
         "status": status
     }
 
     response = api_helpers.get_api_data(test_endpoint, params)
-    # TODO...
+    
+    # parameterization includes all available statuses
+    # validate the correct response code
+    assert response.status_code == 200
+    
+    response_data = response.json()
+    
+    # validate the 'status' property in the response is equal to expected status
+    if response_data: 
+        for pet_data in response_data:
+            assert pet_data["status"] == status
+    
+    # validate the schema for each object in the response
+    for pet_data in response_data:
+        
+        try:
+            validate(instance=pet_data, schema=schemas.pet)
+        except jsonschema.exceptions.ValidationError as e:
+            pytest.fail(f"Schema validation failed for pet data: {pet_data}. Error: {e.message}")
 
-'''
-TODO: Finish this test by...
-1) Testing and validating the appropriate 404 response for /pets/{pet_id}
-2) Parameterizing the test for any edge cases
-'''
-def test_get_by_id_404():
-    # TODO...
-    pass
+
+@pytest.mark.parametrize("pet_id, expected_status, description", [
+    (-1, 404, "negative integer ID"),
+    (999, 404, "non-existent positive ID"),
+    (100, 404, "another non-existent ID"),
+    ("abc", 404, "string ID"),
+    ("1.5", 404, "decimal string ID"),
+    ("-1", 404, "negative string ID"),
+    (None, 404, "null ID"),
+])
+def test_get_by_id_404(pet_id, expected_status, description):
+
+    test_endpoint = f"/pets/{pet_id}"
+    
+    response = api_helpers.get_api_data(test_endpoint)
+    
+    assert response.status_code == expected_status, \
+        f"Expected {expected_status} for {description} (ID: {pet_id}), got {response.status_code}"
+    

--- a/test_store.py
+++ b/test_store.py
@@ -4,13 +4,78 @@ import schemas
 import api_helpers
 from hamcrest import assert_that, contains_string, is_
 
-'''
-TODO: Finish this test by...
-1) Creating a function to test the PATCH request /store/order/{order_id}
-2) *Optional* Consider using @pytest.fixture to create unique test data for each run
-2) *Optional* Consider creating an 'Order' model in schemas.py and validating it in the test
-3) Validate the response codes and values
-4) Validate the response message "Order and pet status updated successfully"
-'''
 def test_patch_order_by_id():
-    pass
+
+    '''Test PATCH /store/order/{order_id}'''
+    
+    # create an order to update
+    order_data = {"pet_id": 2}
+    create_response = api_helpers.post_api_data("/store/order", order_data)
+    assert create_response.status_code == 201
+    
+    order = create_response.json()
+    order_id = order["id"]
+    
+    # test PATCH with valid status update
+    test_endpoint = f"/store/order/{order_id}"
+    update_data = {"status": "sold"}
+    
+    response = api_helpers.patch_api_data(test_endpoint, update_data)
+    
+    # validate response code
+    assert response.status_code == 200
+    
+    # validate response message
+    response_data = response.json()
+    assert "message" in response_data
+    assert response_data["message"] == "Order and pet status updated successfully"
+    
+    # verify pet status was updated
+    pet_response = api_helpers.get_api_data(f"/pets/{order['pet_id']}")
+    pet_data = pet_response.json()
+    assert pet_data["status"] == "sold"
+
+
+@pytest.fixture
+def setup_order():
+
+    """Fixture to create an order for testing and return order data"""
+
+    # get available pet
+    pets_response = api_helpers.get_api_data('/pets/')
+    pets = pets_response.json()
+    
+    # Find an available pet
+    available_pet = None
+    for pet in pets:
+        if pet['status'] == 'available':
+            available_pet = pet
+            break
+    
+    if not available_pet:
+        pytest.skip("No available pets found for testing")
+    
+    # create order
+    order_data = {"pet_id": available_pet['id']}
+    order_response = api_helpers.post_api_data('/store/order', order_data)
+    
+    assert order_response.status_code == 201
+    
+    return order_response.json()
+
+def test_patch_order_with_fixture(setup_order):
+    """Test using pytest fixture"""
+    order = setup_order
+    order_id = order["id"]
+    
+    # test multiple status updates
+    statuses_to_test = ["pending", "sold", "available"]
+    
+    for status in statuses_to_test:
+        response = api_helpers.patch_api_data(
+            f"/store/order/{order_id}",
+            {"status": status}
+        )
+        
+        assert response.status_code == 200
+        assert response.json()["message"] == "Order and pet status updated successfully"


### PR DESCRIPTION
schemas.py - fixed a bug
  name had type set to integer (changed to string)

test_pet.py - improvements
  Parameterized to test all statuses: ["available", "sold", "pending"]
  Validates response code is 200
  Validates each pet's status matches the query
  Validates schema for each pet in response
  Proper error handling for validation failures

test_get_by_id_404 - improvements
  Comprehensive parameterization with 7 test cases
  All return 404 as expected
  Clear error messages for debugging

test_patch_order_by_id:
  Creates order for testing
  Tests PATCH with status update to "sold"
  Validates 200 response
  Validates success message: "Order and pet status updated successfully"
  Verifies pet status sync: Pet status changes to "sold"

setup_order fixture:
  Uses @pytest.fixture as suggested
  Finds available pet automatically
  Handles edge case: Skips if no available pets
  Reusable for multiple tests

test_patch_order_with_fixture:
  Uses fixture for test data
  Tests all statuses: ["pending", "sold", "available"]
  Validates 200 response for each
  Validates success message for each