### PR TITLE
Fix pet schema: name should be string

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -6,7 +6,7 @@ pet = {
             "type": "integer"
         },
         "name": {
-            "type": "integer"
+            "type": "string"
         },
         "type": {
             "type": "string",
@@ -18,3 +18,4 @@ pet = {
         },
     }
 }
+


### PR DESCRIPTION
Fixed incorrect pet schema validation where the pet name was defined as an integer.
All pytest tests pass successfully.

How to run locally:
- Start API: python app.py
- Run tests: pytest -v