### PR TITLE
Complete pytest API tests, OATCH order test and the HTML report

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,10 @@ pytest -v --html=report.html
 - [ ] Extend and fix the 3 tests from [test_pet.py](test_pet.py#1). There are TODO instructions for each test listed in the file
 - [ ] Create the PATCH test for [test_store.py](test_store.py#1). There are TODO instructions for test along with optional tasks
 - [ ] Take note of any bugs you may have found
+
+## Testing Notes
+
+- Tests are executed against a locally running Flask API
+- Parameterized tests validate all pet statuses
+- JSON schema validation is used for API responses
+- HTML test reports are generated using pytest-html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+flask
+flask-restx
+requests
+pytest
+pytest-html
+pyhamcrest
+jsonschema

--- a/schemas.py
+++ b/schemas.py
@@ -6,7 +6,7 @@ pet = {
             "type": "integer"
         },
         "name": {
-            "type": "integer"
+            "type": "string"
         },
         "type": {
             "type": "string",

--- a/schemas.py
+++ b/schemas.py
@@ -2,12 +2,8 @@ pet = {
     "type": "object",
     "required": ["name", "type"],
     "properties": {
-        "id": {
-            "type": "integer"
-        },
-        "name": {
-            "type": "string"
-        },
+        "id": {"type": "integer"},
+        "name": {"type": "string"},
         "type": {
             "type": "string",
             "enum": ["cat", "dog", "fish"]
@@ -15,6 +11,19 @@ pet = {
         "status": {
             "type": "string",
             "enum": ["available", "sold", "pending"]
-        },
+        }
+    }
+}
+
+order = {
+    "type": "object",
+    "required": ["id", "pet_id"],
+    "properties": {
+        "id": {"type": "string"},
+        "pet_id": {"type": "integer"},
+        "status": {
+            "type": "string",
+            "enum": ["available", "sold", "pending"]
+        }
     }
 }

--- a/test_pet.py
+++ b/test_pet.py
@@ -2,45 +2,33 @@ from jsonschema import validate
 import pytest
 import schemas
 import api_helpers
-from hamcrest import assert_that, contains_string, is_
+from hamcrest import assert_that, is_
 
-'''
-TODO: Finish this test by...
-1) Troubleshooting and fixing the test failure
-The purpose of this test is to validate the response matches the expected schema defined in schemas.py
-'''
 def test_pet_schema():
     test_endpoint = "/pets/1"
-
     response = api_helpers.get_api_data(test_endpoint)
 
     assert response.status_code == 200
-
-    # Validate the response schema against the defined schema in schemas.py
     validate(instance=response.json(), schema=schemas.pet)
 
-'''
-TODO: Finish this test by...
-1) Extending the parameterization to include all available statuses
-2) Validate the appropriate response code
-3) Validate the 'status' property in the response is equal to the expected status
-4) Validate the schema for each object in the response
-'''
-@pytest.mark.parametrize("status", [("available")])
+
+@pytest.mark.parametrize("status", ["available", "pending", "sold"])
 def test_find_by_status_200(status):
     test_endpoint = "/pets/findByStatus"
-    params = {
-        "status": status
-    }
+    params = {"status": status}
 
     response = api_helpers.get_api_data(test_endpoint, params)
-    # TODO...
 
-'''
-TODO: Finish this test by...
-1) Testing and validating the appropriate 404 response for /pets/{pet_id}
-2) Parameterizing the test for any edge cases
-'''
-def test_get_by_id_404():
-    # TODO...
-    pass
+    assert response.status_code == 200
+
+    for pet in response.json():
+        assert_that(pet["status"], is_(status))
+        validate(instance=pet, schema=schemas.pet)
+
+
+@pytest.mark.parametrize("pet_id", [999, -1, 10000])
+def test_get_by_id_404(pet_id):
+    test_endpoint = f"/pets/{pet_id}"
+    response = api_helpers.get_api_data(test_endpoint)
+
+    assert response.status_code == 404

--- a/test_store.py
+++ b/test_store.py
@@ -1,16 +1,18 @@
-from jsonschema import validate
-import pytest
-import schemas
 import api_helpers
-from hamcrest import assert_that, contains_string, is_
+from hamcrest import assert_that, is_
 
-'''
-TODO: Finish this test by...
-1) Creating a function to test the PATCH request /store/order/{order_id}
-2) *Optional* Consider using @pytest.fixture to create unique test data for each run
-2) *Optional* Consider creating an 'Order' model in schemas.py and validating it in the test
-3) Validate the response codes and values
-4) Validate the response message "Order and pet status updated successfully"
-'''
 def test_patch_order_by_id():
-    pass
+    order_payload = {"pet_id": 0}
+    create_response = api_helpers.post_api_data("/store/order", order_payload)
+
+    assert create_response.status_code == 201
+    order_id = create_response.json()["id"]
+
+    patch_payload = {"status": "sold"}
+    patch_response = api_helpers.patch_api_data(f"/store/order/{order_id}", patch_payload)
+
+    assert patch_response.status_code == 200
+    assert_that(
+        patch_response.json()["message"],
+        is_("Order and pet status updated successfully")
+    )


### PR DESCRIPTION
I have Completed all required pytest automation tasks as outlined in the README.

Changes:
- Fixed and extended tests in test_pet.py
- Added PATCH test for /store/order/{order_id}
- Validated API responses and JSON schema
- Generated pytest HTML test report

Bugs Observed:
- schemas.py had an incorrect data type for the pet name field
- PATCH order endpoint returns a success message but not the updated order object