### PR TITLE
Added negative tests for the api

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,6 +49,12 @@ pets = [
 
 orders = {}
 
+
+@app.errorhandler(404)
+def handle_not_found(error):
+    message = getattr(error, 'description', 'Not Found')
+    return {'message': message}, 404
+
 '''
 Pet Namespace
 '''

--- a/app.py
+++ b/app.py
@@ -69,7 +69,15 @@ class PetList(Resource):
     @pet_ns.marshal_with(pet_model, code=201)
     def post(self):
         """Create a new pet"""
-        pet = api.payload
+        pet = api.payload or {}
+        if 'name' not in pet or 'type' not in pet:
+            api.abort(400, 'Pet payload must include name and type')
+        if 'id' not in pet or not isinstance(pet['id'], int):
+            api.abort(400, 'Pet payload must include integer id')
+        if pet['type'] not in PET_TYPE:
+            api.abort(400, f"Invalid pet type '{pet['type']}'. Valid types are {', '.join(PET_TYPE)}")
+        if 'status' in pet and pet['status'] not in PET_STATUS:
+            api.abort(400, f"Invalid pet status '{pet['status']}'. Valid statuses are {', '.join(PET_STATUS)}")
         for i in pets:
             if i['id'] == pet['id']:
                 api.abort(409, f"Pet with ID {pet['id']} already exists")
@@ -111,8 +119,12 @@ class OrderResource(Resource):
     @store_ns.marshal_with(order_model, code=201)
     def post(self):
         """Place a new order"""
-        order_data = api.payload
+        order_data = api.payload or {}
         pet_id = order_data.get('pet_id')
+        if pet_id is None:
+            api.abort(400, 'Order payload must include pet_id')
+        if not isinstance(pet_id, int):
+            api.abort(400, 'pet_id must be an integer')
         pet = next((pet for pet in pets if pet['id'] == pet_id), None)
 
         if pet is None:
@@ -142,7 +154,7 @@ class OrderUpdateResource(Resource):
         if order_id not in orders:
             api.abort(404, "Order not found")
 
-        update_data = request.json
+        update_data = request.get_json(silent=True) or {}
         order = orders[order_id]
         pet_id = order['pet_id']
         pet = next((pet for pet in pets if pet['id'] == pet_id), None)
@@ -150,18 +162,22 @@ class OrderUpdateResource(Resource):
         if pet is None:
             api.abort(404, f"No pet found with ID {pet_id}")
 
+        status = update_data.get('status')
+        if status is None:
+            api.abort(400, 'Order update payload must include status')
+        if status not in PET_STATUS:
+            api.abort(400, f"Invalid status '{status}'. Valid statuses are {', '.join(PET_STATUS)}")
+
         # Update the order status
-        order['status'] = update_data['status']
+        order['status'] = status
 
         # Update the pet's status based on the order's new status
-        if update_data['status'] == 'pending':
+        if status == 'pending':
             pet['status'] = 'pending'
-        elif update_data['status'] == 'sold':
+        elif status == 'sold':
             pet['status'] = 'sold'
-        elif update_data['status'] == 'available':
+        elif status == 'available':
             pet['status'] = 'available'
-        else:
-            api.abort(400, f"Invalid status '{update_data['status']}'. Valid statuses are {', '.join(PET_STATUS)}")
 
 
         return {"message": "Order and pet status updated successfully"}

--- a/schemas.py
+++ b/schemas.py
@@ -6,11 +6,28 @@ pet = {
             "type": "integer"
         },
         "name": {
-            "type": "integer"
+            "type": "string"
         },
         "type": {
             "type": "string",
             "enum": ["cat", "dog", "fish"]
+        },
+        "status": {
+            "type": "string",
+            "enum": ["available", "sold", "pending"]
+        },
+    }
+}
+
+order = {
+    "type": "object",
+    "required": ["id", "pet_id"],
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "pet_id": {
+            "type": "integer"
         },
         "status": {
             "type": "string",

--- a/schemas.py
+++ b/schemas.py
@@ -35,3 +35,13 @@ order = {
         },
     }
 }
+
+order_patch_response = {
+    "type": "object",
+    "required": ["message"],
+    "properties": {
+        "message": {
+            "type": "string"
+        }
+    }
+}

--- a/test_negative.py
+++ b/test_negative.py
@@ -1,0 +1,119 @@
+import uuid
+from copy import deepcopy
+
+import pytest
+
+from app import app, orders, pets
+
+
+INITIAL_PETS = deepcopy(pets)
+
+
+def assert_error_response(response, expected_status, expected_message):
+    assert response.status_code == expected_status
+    assert expected_message in response.get_json()["message"]
+
+
+@pytest.fixture(scope="session")
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as test_client:
+        yield test_client
+
+
+@pytest.fixture(autouse=True)
+def reset_app_state():
+    orders.clear()
+    pets[:] = deepcopy(INITIAL_PETS)
+
+
+@pytest.fixture
+def create_order(client):
+    def _create_order(pet_id=2):
+        response = client.post("/store/order", json={"pet_id": pet_id})
+        assert response.status_code == 201
+        return response.get_json()["id"]
+
+    return _create_order
+
+
+@pytest.mark.parametrize(
+    ("query_string", "expected_status", "expected_message"),
+    [
+        ({"status": "unknown"}, 400, "Invalid pet status"),
+        ({}, 400, "Invalid pet status"),
+    ],
+)
+def test_find_by_status_negative_cases(client, query_string, expected_status, expected_message):
+    response = client.get("/pets/findByStatus", query_string=query_string)
+
+    assert_error_response(response, expected_status, expected_message)
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_status", "expected_message"),
+    [
+        ({"pet_id": 9999}, 404, "No pet found"),
+        ({}, 400, "must include pet_id"),
+        ({"pet_id": "abc"}, 400, "pet_id must be an integer"),
+        ({"pet_id": 1}, 400, "is not available for order"),
+    ],
+)
+def test_create_order_negative_cases(client, payload, expected_status, expected_message):
+    response = client.post("/store/order", json=payload)
+
+    assert_error_response(response, expected_status, expected_message)
+
+
+def test_patch_unknown_order_404(client):
+    missing_order_id = str(uuid.uuid4())
+
+    response = client.patch(f"/store/order/{missing_order_id}", json={"status": "sold"})
+
+    assert_error_response(response, 404, "Order not found")
+
+
+@pytest.mark.parametrize(
+    ("payload", "use_json", "expected_status", "expected_message"),
+    [
+        ({"status": "archived"}, True, 400, "Invalid status"),
+        ({}, True, 400, "must include status"),
+        (None, False, 400, "must include status"),
+    ],
+)
+def test_patch_order_negative_cases(
+    client, create_order, payload, use_json, expected_status, expected_message
+):
+    order_id = create_order()
+    request_kwargs = {"json": payload} if use_json else {}
+
+    response = client.patch(f"/store/order/{order_id}", **request_kwargs)
+
+    assert_error_response(response, expected_status, expected_message)
+
+
+def test_create_pet_duplicate_id_409(client):
+    duplicate_pet = {
+        "id": 0,
+        "name": "copycat",
+        "type": "cat",
+        "status": "available",
+    }
+
+    response = client.post("/pets/", json=duplicate_pet)
+
+    assert_error_response(response, 409, "already exists")
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_status", "expected_message"),
+    [
+        ({"id": 10, "type": "cat", "status": "available"}, 400, "include name and type"),
+        ({"id": 11, "name": "copycat", "status": "available"}, 400, "include name and type"),
+        ({"id": 12, "name": "copycat", "type": "bird", "status": "available"}, 400, "Invalid pet type"),
+    ],
+)
+def test_create_pet_invalid_payloads(client, payload, expected_status, expected_message):
+    response = client.post("/pets/", json=payload)
+
+    assert_error_response(response, expected_status, expected_message)

--- a/test_pet.py
+++ b/test_pet.py
@@ -26,7 +26,7 @@ TODO: Finish this test by...
 3) Validate the 'status' property in the response is equal to the expected status
 4) Validate the schema for each object in the response
 '''
-@pytest.mark.parametrize("status", [("available")])
+@pytest.mark.parametrize("status", [("available"), ("sold"), ("pending")])
 def test_find_by_status_200(status):
     test_endpoint = "/pets/findByStatus"
     params = {
@@ -34,13 +34,29 @@ def test_find_by_status_200(status):
     }
 
     response = api_helpers.get_api_data(test_endpoint, params)
-    # TODO...
+    # Validate the response code
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    # Validate the 'status' property in the response
+    for pet in data:
+        assert_that(pet["status"], is_(status))
+        # Validate the schema for each object in the response
+        validate(instance=pet, schema=schemas.pet)
 
 '''
 TODO: Finish this test by...
 1) Testing and validating the appropriate 404 response for /pets/{pet_id}
 2) Parameterizing the test for any edge cases
 '''
-def test_get_by_id_404():
-    # TODO...
-    pass
+#Validates that all three cases return HTTP 404.
+# Parameterizes with edge cases: 999 (nonexistent ID), -1 (negative ID), "invalid" (non-integer string).
+@pytest.mark.parametrize("pet_id", [999, -1, "invalid"])
+def test_get_by_id_404(pet_id):
+    test_endpoint = f"/pets/{pet_id}"
+
+    response = api_helpers.get_api_data(test_endpoint)
+    assert response.status_code == 404
+    # Optionally validate error details in response
+    data = response.json()
+    assert "message" in data or "error" in data

--- a/test_store.py
+++ b/test_store.py
@@ -3,14 +3,41 @@ import pytest
 import schemas
 import api_helpers
 from hamcrest import assert_that, contains_string, is_
+from app import app
 
-'''
-TODO: Finish this test by...
-1) Creating a function to test the PATCH request /store/order/{order_id}
-2) *Optional* Consider using @pytest.fixture to create unique test data for each run
-2) *Optional* Consider creating an 'Order' model in schemas.py and validating it in the test
-3) Validate the response codes and values
-4) Validate the response message "Order and pet status updated successfully"
-'''
-def test_patch_order_by_id():
-    pass
+
+@pytest.fixture(scope="session")
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+@pytest.fixture
+def create_order(client):
+    # Create an order for testing
+    response = client.post('/store/order', json={'pet_id': 0})
+    assert response.status_code == 201
+    order_data = response.get_json()
+    validate(instance=order_data, schema=schemas.order)
+    return order_data['id']
+
+def test_patch_order_by_id(client, create_order):
+    order_id = create_order
+    
+    # Test updating order status to 'sold'
+    update_data = {'status': 'sold'}
+    response = client.patch(f'/store/order/{order_id}', json=update_data)
+    
+    # Validate response code
+    assert response.status_code == 200
+    
+    # Validate response message
+    response_data = response.get_json()
+    validate(instance=response_data, schema=schemas.order_patch_response)
+    assert response_data['message'] == "Order and pet status updated successfully"
+    
+    # Validate the order was updated
+    # Get the order (assuming there's a GET endpoint, but since there isn't, we can check the pet status)
+    # For now, just check that the response is correct
+    # Optional: Validate against schema if we had an order schema
+    # But since the response is just a message, no need


### PR DESCRIPTION
test_pet_schema was failing because schemas.py expected name to be an integer.
The app in app.py could throw server errors on malformed requests like missing pet_id or missing status.
Negative coverage was limited, and the tests had repeated setup/assertion code.
The project environment was missing required packages to run tests and start the app.Fixed the schema mismatch in schemas.py.
Hardened app.py so invalid payloads return proper 400 responses.
Added and refactored test_negative.py with reusable fixtures, helper assertions, and parameterized negative tests.
Installed the missing dependencies and verified everything runs cleanly.
Final result: full test suite passes with 22 passed.

<img width="893" height="497" alt="image" src="https://github.com/user-attachments/assets/2d93adbf-5e30-4b50-bb70-98a985949635" />
